### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # GRR Rapid Response
 
-Publisher: Splunk \
-Connector Version: 2.0.6 \
-Product Vendor: Google \
-Product Name: GRR Rapid Response \
+Publisher: Splunk <br>
+Connector Version: 2.0.6 <br>
+Product Vendor: Google <br>
+Product Name: GRR Rapid Response <br>
 Minimum Product Version: 5.2.0
 
 This app implements various investigative actions from the GRR API
@@ -21,20 +21,20 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[list connections](#action-list-connections) - List all the connections configured on the device \
-[list endpoints](#action-list-endpoints) - List all the endpoints/sensors configured on the device \
-[get system info](#action-get-system-info) - Get information about an endpoint \
-[get file info](#action-get-file-info) - Look for files matching given criteria \
-[get browser cache](#action-get-browser-cache) - Retrieve matching regex in a client's browser cache \
-[get hunts](#action-get-hunts) - Retrieve available hunts \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[list connections](#action-list-connections) - List all the connections configured on the device <br>
+[list endpoints](#action-list-endpoints) - List all the endpoints/sensors configured on the device <br>
+[get system info](#action-get-system-info) - Get information about an endpoint <br>
+[get file info](#action-get-file-info) - Look for files matching given criteria <br>
+[get browser cache](#action-get-browser-cache) - Retrieve matching regex in a client's browser cache <br>
+[get hunts](#action-get-hunts) - Retrieve available hunts <br>
 [get cron jobs](#action-get-cron-jobs) - Retrieve available cron jobs
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -49,7 +49,7 @@ No Output
 
 List all the connections configured on the device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -85,7 +85,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List all the endpoints/sensors configured on the device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -160,7 +160,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get information about an endpoint
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -239,7 +239,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Look for files matching given criteria
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -285,7 +285,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Retrieve matching regex in a client's browser cache
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -348,7 +348,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Retrieve available hunts
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -395,7 +395,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Retrieve available cron jobs
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/grr.json
+++ b/grr.json
@@ -20,7 +20,7 @@
         "On-prem, GRR Rapid Response v3.2.0.1"
     ],
     "app_wizard_version": "1.0.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "configuration": {
         "username": {
             "description": "Username",

--- a/grr.json
+++ b/grr.json
@@ -2177,5 +2177,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Update NOTICE file with updated dependencies
 * Apply pre-commit fixes
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)