### PR TITLE
[PAPP-38196] Harden GRR paths, TLS, and flow handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2018-2025 Splunk Inc.
+   Copyright (c) 2018-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: GRR Rapid Response
-Copyright (c) 2018-2025 Splunk Inc.
+Copyright (c) 2018-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/grr.json
+++ b/grr.json
@@ -9,7 +9,7 @@
     "product_name": "GRR Rapid Response",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2018-2025 Splunk Inc.",
+    "license": "Copyright (c) 2018-2026 Splunk Inc.",
     "app_version": "2.0.7",
     "utctime_updated": "2025-09-05T16:35:33.031284Z",
     "package_name": "phantom_grr",

--- a/grr.json
+++ b/grr.json
@@ -44,7 +44,7 @@
             "description": "Verify server certificate",
             "data_type": "boolean",
             "order": 1,
-            "default": false
+            "default": true
         }
     },
     "actions": [

--- a/grr_connector.py
+++ b/grr_connector.py
@@ -355,7 +355,7 @@ class GrrConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID])
+        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
 
         endpoint = f"/api/v2/clients/{client_id}/flows"
 
@@ -460,7 +460,7 @@ class GrrConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID])
+        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
 
         if client_id is None:
             return action_result.set_status(phantom.APP_ERROR, "Please specify client id")
@@ -500,7 +500,7 @@ class GrrConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID])
+        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
         file_path = param[GRR_JSON_FILE_PATH]
 
         endpoint = f"/api/v2/clients/{client_id}/flows"
@@ -558,7 +558,7 @@ class GrrConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID])
+        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
         regex = param[GRR_JSON_BROWSER_CACHE_REGEX]
         users = [x.strip() for x in str(param[GRR_JSON_USERS]).split(",") if x.strip()]  # might need to format if multiple users
 

--- a/grr_connector.py
+++ b/grr_connector.py
@@ -1,6 +1,6 @@
 # File: grr_connector.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/grr_connector.py
+++ b/grr_connector.py
@@ -235,11 +235,17 @@ class GrrConnector(BaseConnector):
             ret_val, resp_json = self._verify_response(r, action_result)
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
-            if resp_json["state"] != "RUNNING":
-                # Flow has finished
-                break
+            state = resp_json.get("state")
+            if state == "TERMINATED":
+                return phantom.APP_SUCCESS
+            if state != "RUNNING":
+                context = resp_json.get("context", {})
+                detail = context.get("status") or context.get("backtrace")
+                message = f"Flow {flow_id} ended in state {state or 'UNKNOWN'}"
+                if detail:
+                    message = f"{message}: {detail}"
+                return action_result.set_status(phantom.APP_ERROR, message)
             time.sleep(1)
-        return phantom.APP_SUCCESS
 
     def _get_flow_result(self, endpoint, action_result):
         self.save_progress("Retrieving flow results")

--- a/grr_connector.py
+++ b/grr_connector.py
@@ -144,7 +144,7 @@ class GrrConnector(BaseConnector):
                 auth=(config[GRR_JSON_USERNAME], config[GRR_JSON_PASSWORD]),  # basic authentication
                 data=data,
                 headers=headers,
-                verify=config.get(GRR_JSON_VERIFY_SERVER_CERT, False),
+                verify=config.get(GRR_JSON_VERIFY_SERVER_CERT, True),
                 params=params,
             )
         except Exception as e:
@@ -164,7 +164,7 @@ class GrrConnector(BaseConnector):
         config = self.get_config()
         url = self._base_url + endpoint
         auth = (config[GRR_JSON_USERNAME], config[GRR_JSON_PASSWORD])
-        verify_cert = config.get(GRR_JSON_VERIFY_SERVER_CERT, False)
+        verify_cert = config.get(GRR_JSON_VERIFY_SERVER_CERT, True)
         s = requests.Session()
         s.auth = auth
 

--- a/grr_connector.py
+++ b/grr_connector.py
@@ -222,8 +222,12 @@ class GrrConnector(BaseConnector):
 
     def _wait_for_flow(self, address, s, action_result, verify_cert=False):
         self.save_progress("Waiting for flow to complete")
+        flow_id = address.rsplit("/", 1)[-1].split("?", 1)[0]
+        deadline = time.monotonic() + FLOW_WAIT_TIMEOUT
 
         while True:
+            if time.monotonic() >= deadline:
+                return action_result.set_status(phantom.APP_ERROR, f"Flow {flow_id} did not complete within {FLOW_WAIT_TIMEOUT} seconds")
             try:
                 r = s.get(address, verify=verify_cert, timeout=DEFAULT_REQUEST_TIMEOUT)
             except Exception as e:

--- a/grr_consts.py
+++ b/grr_consts.py
@@ -1,6 +1,6 @@
 # File: grr_consts.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/grr_consts.py
+++ b/grr_consts.py
@@ -28,3 +28,4 @@ GRR_JSON_VERIFY_SERVER_CERT = "verify_server_cert"
 GRR_INVALID_COUNT_MSG = "Please provide a non-zero positive integer in the {param_name} parameter"
 GRR_INVALID_OFFSET_MSG = "Please provide a non-negative integer in the {param_name} parameter"
 DEFAULT_REQUEST_TIMEOUT = 30  # in seconds
+FLOW_WAIT_TIMEOUT = 600  # in seconds

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Encoded GRR client IDs as single URL path segments before API requests.
 * Enabled GRR server certificate verification by default while preserving an explicit opt-out.
+* Stopped waiting for a GRR flow after ten minutes and reported its flow ID for follow-up.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Encoded GRR client IDs as single URL path segments before API requests.
+* Enabled GRR server certificate verification by default while preserving an explicit opt-out.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Encoded GRR client IDs as single URL path segments before API requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Encoded GRR client IDs as single URL path segments before API requests.
 * Enabled GRR server certificate verification by default while preserving an explicit opt-out.
 * Stopped waiting for a GRR flow after ten minutes and reported its flow ID for follow-up.
+* Reported failed, crashed, and unknown GRR flow states as action errors.


### PR DESCRIPTION
## Summary

- encode caller-supplied client IDs as single URL path segments
- enable GRR server certificate verification by default
- stop flow polling after ten minutes and report the flow ID
- treat failed, crashed, and unknown terminal flow states as action errors
- refresh generated connector build artifacts with dev-cicd-tools v2.2.4

## Breaking change

Assets that omit `verify_server_cert` now verify the GRR server certificate. Operators can still explicitly disable verification.

## Tracking

- Parent: [PAPP-38196](https://splunk.atlassian.net/browse/PAPP-38196)
- Findings: [PSAAS-30567](https://splunk.atlassian.net/browse/PSAAS-30567), [PSAAS-30787](https://splunk.atlassian.net/browse/PSAAS-30787), [PSAAS-31911](https://splunk.atlassian.net/browse/PSAAS-31911), [PSAAS-32321](https://splunk.atlassian.net/browse/PSAAS-32321)
- PSAAS-31645, PSAAS-31691, PSAAS-31699, and PSAAS-31700 were handled separately as invalid read-only findings.

## Validation

- `pre-commit run --all-files`
- `python3 -m compileall -q grr_connector.py grr_consts.py`

Written by Codex.