### PR TITLE
fix: validate GRR client identifiers

### DIFF
--- a/grr_connector.py
+++ b/grr_connector.py
@@ -27,6 +27,7 @@ from phantom.base_connector import BaseConnector
 
 # Usage of the consts file is recommended
 from grr_consts import *
+from grr_validation import validate_client_id
 
 
 class RetVal(tuple):
@@ -365,7 +366,11 @@ class GrrConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
+        try:
+            client_id = validate_client_id(param[GRR_JSON_CLIENT_ID])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
+        client_id = requests.compat.quote(client_id, safe="")
 
         endpoint = f"/api/v2/clients/{client_id}/flows"
 
@@ -470,10 +475,11 @@ class GrrConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
-
-        if client_id is None:
-            return action_result.set_status(phantom.APP_ERROR, "Please specify client id")
+        try:
+            client_id = validate_client_id(param[GRR_JSON_CLIENT_ID])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
+        client_id = requests.compat.quote(client_id, safe="")
 
         endpoint = f"/api/v2/clients/{client_id}"
 
@@ -510,7 +516,11 @@ class GrrConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
+        try:
+            client_id = validate_client_id(param[GRR_JSON_CLIENT_ID])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
+        client_id = requests.compat.quote(client_id, safe="")
         file_path = param[GRR_JSON_FILE_PATH]
 
         endpoint = f"/api/v2/clients/{client_id}/flows"
@@ -568,7 +578,11 @@ class GrrConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        client_id = requests.compat.quote(param[GRR_JSON_CLIENT_ID], safe="")
+        try:
+            client_id = validate_client_id(param[GRR_JSON_CLIENT_ID])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
+        client_id = requests.compat.quote(client_id, safe="")
         regex = param[GRR_JSON_BROWSER_CACHE_REGEX]
         users = [x.strip() for x in str(param[GRR_JSON_USERS]).split(",") if x.strip()]  # might need to format if multiple users
 

--- a/grr_validation.py
+++ b/grr_validation.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+GRR_CLIENT_ID_PATTERN = re.compile(r"C\.[0-9a-fA-F]{16}\Z")
+
+
+def validate_client_id(value: object) -> str:
+    """Return a GRR client ID after enforcing its complete path-segment grammar."""
+    client_id = str(value)
+    if not GRR_CLIENT_ID_PATTERN.fullmatch(client_id):
+        raise ValueError("Client ID must use the format C. followed by 16 hexadecimal characters")
+    return client_id

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Enforce the complete GRR client identifier format before constructing client API paths.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,20 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
+import unittest
 
 from grr_validation import validate_client_id
 
 
-@pytest.mark.parametrize("value", ["C.0123456789abcdef", "C.ABCDEF0123456789"])
-def test_validate_client_id_accepts_grr_grammar(value):
-    assert validate_client_id(value) == value
+class ValidateClientIdTest(unittest.TestCase):
+    def test_accepts_grr_grammar(self):
+        for value in ("C.0123456789abcdef", "C.ABCDEF0123456789"):
+            with self.subTest(value=value):
+                self.assertEqual(validate_client_id(value), value)
 
-
-@pytest.mark.parametrize(
-    "value",
-    [".", "..", "../config", "C.0123456789abcde", "C.0123456789abcdef0", "c.0123456789abcdef", "C.0123456789abcdeg"],
-)
-def test_validate_client_id_rejects_non_grr_values(value):
-    with pytest.raises(ValueError):
-        validate_client_id(value)
+    def test_rejects_non_grr_values(self):
+        invalid_values = (".", "..", "../config", "C.0123456789abcde", "C.0123456789abcdef0", "c.0123456789abcdef", "C.0123456789abcdeg")
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                validate_client_id(value)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from grr_validation import validate_client_id
+
+
+@pytest.mark.parametrize("value", ["C.0123456789abcdef", "C.ABCDEF0123456789"])
+def test_validate_client_id_accepts_grr_grammar(value):
+    assert validate_client_id(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [".", "..", "../config", "C.0123456789abcde", "C.0123456789abcdef0", "c.0123456789abcdef", "C.0123456789abcdeg"],
+)
+def test_validate_client_id_rejects_non_grr_values(value):
+    with pytest.raises(ValueError):
+        validate_client_id(value)


### PR DESCRIPTION
## Summary

- enforce the documented `C.` plus 16 hexadecimal character grammar for GRR client identifiers
- apply the same validation before all four client and flow API path constructions
- retain path-segment encoding as defense in depth
- add focused regression coverage for valid identifiers, exact dot segments, traversal values, and malformed identifiers

## Quality gate

- focused tests: 9 passed
- required local hooks: passed
- local Semgrep was unavailable because the sandbox trust store was empty
- local dependency packaging was unavailable because Docker was not running

Follow-up for [PAPP-38196](https://splunk.atlassian.net/browse/PAPP-38196) and [PSAAS-30567](https://splunk.atlassian.net/browse/PSAAS-30567). The exact source revision will be validated against [VULN-93292](https://splunk.atlassian.net/browse/VULN-93292) before this draft is marked ready.

Authored by Codex for Scott Odle.
